### PR TITLE
docker-compose.ymlを環境変数を用いて書き換え

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+/.env

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,7 +15,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV.fetch('MYSQL_USER') { 'user' } %>
   password: <%= ENV.fetch('MYSQL_PASSWORD') { 'password' } %>
-  host: mysql
+  host: <%= ENV['MYSQL_HOST'] || 'localhost' %>
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,8 @@ services:
       - /cafeapp/log
     environment:
       TZ: 'Asia/Tokyo'
-      MYSQL_USER: user
-      MYSQL_PASSWORD: password
-      MYSQL_HOST: mysql
+    env_file:
+      - .env
     tty: true
     stdin_open: true
     command: bundle exec rails server -p 3000 -b 0.0.0.0
@@ -31,9 +30,8 @@ services:
       - gem_data:/usr/local/bundle
     environment:
       TZ: 'Asia/Tokyo'
-      MYSQL_ROOT_PASSWORD: root_password
-      MYSQL_USER: user
-      MYSQL_PASSWORD: password
+    env_file:
+      - .env
     ports:
       - '3306:3306'
   web:


### PR DESCRIPTION
### 変更の概要
環境変数の使用に.envファイルを適用

### なぜこの変更をするのか
セキュリティの観点から、gitに環境変数をpushしたくない

### やったこと

- [ ] .envファイルを作成し、環境変数を記述
- [ ] gitignoreで.envを管理対象から除外
- [ ] docker-compose.ymlで環境変数は.envを参照するよう変更