### PR TITLE
マイページ(お気に入りページ、レビュー一覧ページ、アカウント情報変更ページ）実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,5 +3,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,2 @@
 class ApplicationController < ActionController::Base
-  before_action :configure_permitted_parameters, if: :devise_controller?
-
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar])
-  end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,5 +1,10 @@
 class ReviewsController < ApplicationController
   before_action :authenticate_user!
+  before_action :where_access_from, only: [:update, :destroy]
+
+  def index
+    @my_reviews = Review.where(user_id: current_user.id)
+  end
 
   def create
     @review = Review.new(review_params)
@@ -24,6 +29,7 @@ class ReviewsController < ApplicationController
     @review = Review.find(params[:id])
     @shop_id = @review.shop_id
     @reviews = Review.where(shop_id: @shop_id).order(created_at: "DESC")
+    @my_reviews = Review.where(user_id: current_user.id)
     if @review.update(review_params)
       flash.now[:notice] = "口コミを編集しました"
       respond_to do |format|
@@ -40,6 +46,7 @@ class ReviewsController < ApplicationController
     @review_id = @review.id
     @shop_id = @review.shop_id
     @reviews = Review.where(shop_id: @shop_id).order(created_at: "DESC")
+    @my_reviews = Review.where(user_id: current_user.id)
     @review.destroy
     flash.now[:alert] = "投稿を削除しました"
     respond_to do |format|
@@ -50,6 +57,10 @@ class ReviewsController < ApplicationController
 
   private
   def review_params
-    params.require(:review).permit(:comment, :title, :shop_id, :user_id, :rate)
+    params.require(:review).permit(:comment, :title, :shop_id, :shop_name, :user_id, :rate)
+  end
+
+  def where_access_from
+    @path = Rails.application.routes.recognize_path(request.referer)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,50 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_account_update_params, only: [:update]
+
+  def new
+    super
+  end
+
+  def create
+    super
+  end
+
+  def edit
+    super
+  end
+
+  def update
+    super
+  end
+
+  def destroy
+    super
+  end
+
+  def cancel
+    super
+  end
+
+  protected
+
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
+
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar])
+  end
+
+  def after_sign_up_path_for(resource)
+    super(resource)
+  end
+
+  def after_inactive_sign_up_path_for(resource)
+    super(resource)
+  end
+
+  def after_update_path_for(resource)
+    edit_user_registration_path
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -19,5 +19,6 @@ import "@fortawesome/fontawesome-free/js/all"
 import "../stylesheets/application.scss"
 import '../stylesheets/favorites.scss'
 import '../stylesheets/searches.scss'
+import '../stylesheets/reviews.scss'
 import '../stylesheets/shops.scss'
 import '../stylesheets/user.scss'

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -167,7 +167,6 @@ header {
 
 .footer {
   width: 100%;
-  margin-top: 30px;
   padding-top: 50px;
   padding-bottom: 10px;
   background-color: #262b2c;

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -139,7 +139,7 @@ header {
     width: 60px;
     height: 60px;
     margin: 0 16px;
-    padding: 7px;
+    padding: 5px;
     border-radius: 50px;
     -o-object-fit: cover;
       object-fit: cover;

--- a/app/javascript/stylesheets/reviews.scss
+++ b/app/javascript/stylesheets/reviews.scss
@@ -1,3 +1,22 @@
-// Place all the styles related to the reviews controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
+.review-shop-name {
+  a {
+    &:hover {
+      color: orange;
+    }
+  }
+}
+
+.rv-comment {
+  font-size: 1.5rem;
+}
+
+.user-review-wrapper {
+  display: flex;
+  flex-grow: 1;
+  justify-content: center;
+}
+
+.user-review-inner {
+  width: 70%;
+  margin: 5rem auto 0 auto;
+}

--- a/app/javascript/stylesheets/reviews.scss
+++ b/app/javascript/stylesheets/reviews.scss
@@ -14,9 +14,15 @@
   display: flex;
   flex-grow: 1;
   justify-content: center;
+  padding-bottom: 3rem;
 }
 
 .user-review-inner {
   width: 70%;
   margin: 5rem auto 0 auto;
+}
+
+.no-review {
+  margin-top: 1rem;
+  font-size: 1.5rem;
 }

--- a/app/javascript/stylesheets/shops.scss
+++ b/app/javascript/stylesheets/shops.scss
@@ -179,7 +179,7 @@
   }
 }
 
-.review-user-header {
+.review-user-header, .review-shop-header {
   display: flex;
   align-items: center;
   border-bottom: 2px solid #ebe8d9;
@@ -197,7 +197,7 @@
   }
 }
 
-.review-user-name {
+.review-user-name, .review-shop-name {
   flex-grow: 1;
   font-size: 1.5rem;
   text-align: left;

--- a/app/javascript/stylesheets/user.scss
+++ b/app/javascript/stylesheets/user.scss
@@ -13,10 +13,35 @@
   width: 50%;
   margin-top: 5rem;
   .field {
-    margin-top: .5rem;
+    margin-top: 1rem;
+  }
+  div {
+    &:first-child {
+      margin-top: 2rem;
+    }
   }
   .actions {
     margin-top: 1rem;
+  }
+}
+
+.edit-current-user-img {
+  display: flex;
+  align-items: flex-end;
+  input {
+    font-size: 1rem!important;
+  }
+}
+
+.edit-current-user-img {
+  img {
+    width: 80px;
+    height: 80px;
+    margin: 0 16px;
+    padding: 2px;
+    border-radius: 50px;
+    -o-object-fit: cover;
+      object-fit: cover;
   }
 }
 

--- a/app/javascript/stylesheets/user.scss
+++ b/app/javascript/stylesheets/user.scss
@@ -1,6 +1,6 @@
 .user-edit-wrapper {
-  flex-grow: 1;
   display: flex;
+  flex-grow: 1;
   justify-content: center;
 }
 
@@ -10,14 +10,26 @@
 }
 
 .user-edit-inner {
-  margin-top: 5rem;
   width: 50%;
+  margin-top: 5rem;
   .field {
-    margin-top: 0.5rem;
+    margin-top: .5rem;
   }
   .actions {
     margin-top: 1rem;
   }
+}
+
+.user-favorite-wrapper {
+  display: flex;
+  flex-grow: 1;
+  justify-content: center;
+  padding-bottom: 3rem;
+}
+
+.user-favorite-inner {
+  width: 85%;
+  margin: 0 auto;
 }
 
 .account-delete-title {
@@ -55,9 +67,7 @@
     position: absolute;
     top: 50%;
     left: 50%;
-    -webkit-transform: translate(-45%, -50%);
-        -ms-transform: translate(-45%, -50%);
-            transform: translate(-45%, -50%);
+    transform: translate(-45%, -50%);
     margin: 0;
     padding: 15px;
     border-radius: 50%;
@@ -120,11 +130,11 @@
 }
 
 .side-bar-link {
+  padding: 1rem;
+  border-right: 6px solid #ffa35f;
+  background-color: #faf4e6;
+  color: #212529;
   font-size: 1.5rem;
-    padding: 1rem;
-    background-color: #faf4e6;
-    border-right: 6px solid #ffa35f;
-    color: #212529;
   &:hover {
     background-color: #fffbf4;
   }

--- a/app/javascript/stylesheets/user.scss
+++ b/app/javascript/stylesheets/user.scss
@@ -131,11 +131,14 @@
 
 .side-bar-link {
   padding: 1rem;
-  border-right: 6px solid #ffa35f;
   background-color: #faf4e6;
   color: #212529;
   font-size: 1.5rem;
   &:hover {
     background-color: #fffbf4;
   }
+}
+
+.active {
+  border-right: 6px solid #ffa35f;
 }

--- a/app/javascript/stylesheets/user.scss
+++ b/app/javascript/stylesheets/user.scss
@@ -1,3 +1,38 @@
+.user-edit-wrapper {
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.user-edit-frame {
+  display: flex;
+  justify-content: center;
+}
+
+.user-edit-inner {
+  margin-top: 5rem;
+  width: 50%;
+  .field {
+    margin-top: 0.5rem;
+  }
+  .actions {
+    margin-top: 1rem;
+  }
+}
+
+.account-delete-title {
+  margin-top: 2rem;
+}
+
+.account-delete-text {
+  display: inline-block;
+  margin-right: 1rem;
+}
+
+.button_to {
+  display: inline-block;
+}
+
 .user-main-wrapper {
   flex-grow: 1;
   position: relative;
@@ -74,5 +109,23 @@
   text-align: center;
   a {
     margin-top: 15px;
+  }
+}
+
+.side-bar-wrapper {
+  width: 15%;
+  ul {
+    margin-top: 2rem;
+  }
+}
+
+.side-bar-link {
+  font-size: 1.5rem;
+    padding: 1rem;
+    background-color: #faf4e6;
+    border-right: 6px solid #ffa35f;
+    color: #212529;
+  &:hover {
+    background-color: #fffbf4;
   }
 }

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -6,6 +6,7 @@ class Review < ApplicationRecord
   validates :comment, presence: true
   validates :user_id, presence: true
   validates :shop_id, presence: true
+  validates :shop_name, presence: true
   validates :rate, numericality: {
     less_than_or_equal_to: 5,
     greater_than_or_equal_to: 1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ApplicationRecord
 
   def validate_avatar
     return unless avatar.attached?
-    if avatar.blob.byte_size > 2.megabytes
+    if avatar.blob.byte_size > 1.megabytes
       errors.add(:avatar, 'のサイズは2MBまでです')
     elsif !image?
       errors.add(:avatar, 'が対応している画像データではありません')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,14 @@
 class User < ApplicationRecord
+  VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :rememberable, :validatable
 
   validates :email, uniqueness: true
   validates :name, uniqueness: true, presence: true
+  validate :validate_avatar
+  validate :password_complexity
 
   has_one_attached :avatar
   has_many :reviews, dependent: :destroy
@@ -17,5 +20,25 @@ class User < ApplicationRecord
 
   def favorite_id(shop_id)
     favorites.find_by(shop_id: shop_id).id
+  end
+
+  def password_complexity
+    return if password.blank? || password =~ VALID_PASSWORD_REGEX
+    errors.add(:password, 'は英数字混合である必要があります')
+  end
+
+  def validate_avatar
+    return unless avatar.attached?
+    if avatar.blob.byte_size > 2.megabytes
+      errors.add(:avatar, 'のサイズは2MBまでです')
+    elsif !image?
+      errors.add(:avatar, 'が対応している画像データではありません')
+    end
+  end
+
+  private
+
+  def image?
+    %w[image/jpg image/jpeg image/png].include?(avatar.blob.content_type)
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -24,16 +24,8 @@
             <%= f.label :email %>
             <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
           </div>
-
-          <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-            <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
-          <% end %>
-
           <div class="field">
-            <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
-            <% if @minimum_password_length %>
-              <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-            <% end %>
+            <%= f.label :password %> <i>空欄のままなら変更しません</i><em>(6文字以上 英数字混合)</em>
             <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
           </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,52 @@
-<h2><%= t('.title', resource: resource.model_name.human) %></h2>
+<div class="user-edit-wrapper">
+  <%= render "shared/sidebar" %>
+  <div class="container">
+    <div class="user-edit-frame">
+      <div class="user-edit-inner">
+        <h2>アカウント情報編集</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+        <%= form_with model: @user, url:  user_registration_path, local: true do |f| %>
+          <%= render "devise/shared/error_messages", resource: resource %>
+          <div class="field">
+            <%= f.label :name %>
+            <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
+          </div>
+          <div class="field">
+            <%= f.label :email %>
+            <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
+          </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+          <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+            <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
+          <% end %>
+
+          <div class="field">
+            <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
+            <% if @minimum_password_length %>
+              <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+            <% end %>
+            <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+          </div>
+
+          <div class="field">
+            <%= f.label :password_confirmation %>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+          </div>
+
+          <div class="field">
+            <%= f.label :current_password %> <i>(変更を反映するには現在のパスワードを入力してください)</i>
+            <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
+          </div>
+
+          <div class="actions">
+            <%= f.submit "更新する", class: "btn btn-primary" %>
+          </div>
+        <% end %>
+
+        <h3 class="account-delete-title">アカウント削除</h3>
+
+        <p class="account-delete-text">アカウント削除はこちらから<%= button_to "アカウント削除", registration_path(resource_name), data: { confirm: "本当に削除しますか？" }, method: :delete %></p>
+      </div>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit t('.update') %>
-  </div>
-<% end %>
-
-<h3><%= t('.cancel_my_account') %></h3>
-
-<p><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %></p>
-
-<%= link_to t('devise.shared.links.back'), :back %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,9 +4,18 @@
     <div class="user-edit-frame">
       <div class="user-edit-inner">
         <h2>アカウント情報編集</h2>
-
         <%= form_with model: @user, url:  user_registration_path, local: true do |f| %>
           <%= render "devise/shared/error_messages", resource: resource %>
+          <div class="field">
+            <div class="edit-current-user-img">
+              <% if current_user.avatar.attached? %>
+                <%= image_tag current_user.avatar.variant(resize:"300x300^", gravity: :center, crop:"300x300+0+0").processed, id: "current-user-img" %>
+              <% else %>
+                <%= image_tag "/default_icon.jpg", id: "current-user-img" %>
+              <% end %>
+              <%= f.file_field :avatar %>
+            </div>
+          </div>
           <div class="field">
             <%= f.label :name %>
             <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
@@ -39,7 +48,7 @@
           </div>
 
           <div class="actions">
-            <%= f.submit "更新する", class: "btn btn-primary" %>
+            <%= f.submit "更新する", class: "btn md-btn btn-primary" %>
           </div>
         <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -19,9 +19,7 @@
 
           <div class="field">
             <%= f.label :password %>
-            <% if @minimum_password_length %>
-              <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-            <% end %>
+            <em>(6文字以上 英数字混合)</em>
             <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
           </div>
 
@@ -31,7 +29,7 @@
           </div>
 
           <div class="actions my-3">
-            <%= f.submit t('.sign_up'), class: "btn-primary btn md-btn" %>
+            <%= f.submit "新規登録", class: "btn-primary btn md-btn" %>
           </div>
         <% end %>
         <%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,7 +14,7 @@
 
           <div class="field">
             <%= f.label :email %>
-            <%= f.email_field :email, autofocus: true, autocoimplete: "email", class: "form-control" %>
+            <%= f.email_field :email, autocoimplete: "email", class: "form-control" %>
           </div>
 
           <div class="field">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -3,31 +3,25 @@
     <div class="container">
       <div class="form-wrapper">
         <h2>アカウント登録</h2>
-
         <%= form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f| %>
           <%= render "devise/shared/error_messages", resource: resource %>
-
           <div class="field">
             <%= f.label :name %>
             <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
           </div>
-
           <div class="field">
             <%= f.label :email %>
             <%= f.email_field :email, autocoimplete: "email", class: "form-control" %>
           </div>
-
           <div class="field">
             <%= f.label :password %>
             <em>(6文字以上 英数字混合)</em>
             <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
           </div>
-
           <div class="field">
             <%= f.label :password_confirmation %>
             <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
           </div>
-
           <div class="actions my-3">
             <%= f.submit "新規登録", class: "btn-primary btn md-btn" %>
           </div>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,7 +1,12 @@
-<div class="container">
-  <div class="favorite-index-title">
-    <h1>お気に入り一覧</h1>
-    <p>※20件まで保存できます</p>
+<div class="user-favorite-wrapper">
+  <%= render "shared/sidebar" %>
+  <div class="container">
+    <div class="user-favorite-inner">
+      <div class="favorite-index-title">
+        <h1>お気に入り一覧</h1>
+        <p>※20件まで保存できます</p>
+      </div>
+      <%= render "shared/card", shops: @shops %>
+    </div>
   </div>
-  <%= render "shared/card", shops: @shops %>
 </div>

--- a/app/views/reviews/_my_review_index.html.erb
+++ b/app/views/reviews/_my_review_index.html.erb
@@ -79,7 +79,7 @@
     </script>
   <% end %>
 <% else %>
-  <div class="review-inner" id="reviews">
-    <p>現在クチコミはありません</p>
+  <div class="review-inner">
+    <p class="no-review">現在クチコミはありません</p>
   </div>
 <% end %>

--- a/app/views/reviews/_my_review_index.html.erb
+++ b/app/views/reviews/_my_review_index.html.erb
@@ -1,0 +1,85 @@
+<h1>マイレビュー一覧</h1>
+<% if reviews.present? %>
+  <% reviews.each do |review| %>
+    <div class="review-frame" id="rv-wrapper-<%= review.id %>">
+      <div class="review-shop-header">
+        <div class="review-shop-name">
+          <%= link_to shop_path(shop_id: review.shop_id) do%>
+            <%= review.shop_name %>
+          <% end %>
+        </div>
+        <div class="raview-rate-wrapper">
+          <div id="star-rate<%= review.id %>"></div>
+          <span><%= review.rate %></span>
+        </div>
+      </div>
+      <div class="review-main-content">
+        <h5 class="rv-title" id="rv-title-<%= review.id %>"><%= review.title %></h5>
+        <p class="rv-comment" id="rv-comment-<%= review.id %>"><%= safe_join(review.comment.split("\n"),tag(:br)) %></p>
+        <div class="edit-delete-btn">
+          <%= link_to edit_review_path(review), 'data-bs-toggle': :"modal", 'data-bs-target': :"#reviewEditModal#{review.id}", remote: true do %>
+            <i class="far fa-edit"></i>
+          <% end %>
+          <%= link_to review_path(review), data: { confirm: '削除しますか?' }, method: :delete, remote: true do %>
+            <i class="far fa-trash-alt"></i>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <div class="modal fade" id="reviewEditModal<%= review.id %>" tabindex="-1" aria-labelledby="reviewEditModalLabel<%= review.id %>" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered modal-container">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="reviewEditModalLabel<%= review.id %>">口コミ編集</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <%= form_with(model: review, local: false) do |f| %>
+            <div class="modal-body">
+              <div id="edit-error">
+                <%= render "devise/shared/error_messages", resource: f.object %>
+              </div>
+              <div class="form-group" id="re-star-<%= review.id %>">
+                <%= f.label :rate, "評価" %>
+                <%= f.hidden_field :rate, id: :review_star %>
+              </div>
+              <div class="form-group">
+                <%= f.text_field :title, class: "form-control review-form", placeholder: "タイトルを入力してください" %>
+              </div>
+              <div class="form-group">
+                <%= f.text_area :comment, class: "form-control review-form", placeholder: "本文を入力してください" %>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn md-btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
+              <%= f.submit "投稿する", class: "btn md-btn btn-primary" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <script>
+      $("#star-rate<%= review.id %>").raty({
+        size: 36,
+        starOff: "star-off.png",
+        starOn: "star-on.png",
+        starHalf: "star-half.png",
+        half: true,
+        readOnly: true,
+        score: "<%= review.rate %>",
+      });
+      $("#re-star-<%= review.id %>").raty({
+        size: 36,
+        starOff: "star-off.png",
+        starOn: "star-on.png",
+        starHalf: "star-half.png",
+        scoreName: "review[rate]",
+        half: true,
+        score: "<%= review.rate %>"
+      });
+    </script>
+  <% end %>
+<% else %>
+  <div class="review-inner" id="reviews">
+    <p>現在クチコミはありません</p>
+  </div>
+<% end %>

--- a/app/views/reviews/destroy.js.erb
+++ b/app/views/reviews/destroy.js.erb
@@ -1,5 +1,12 @@
-$(function(){
-  $("#shop-review-content").html("<%= j(render"reviews", reviews: @reviews) %>");
-  $("#flash-message").html("<%= j(render "shared/flash") %>");
-  $("#shop-avg-rate").html("<%= j(render "shared/star_rate", shop_id: @shop_id, reviews: @reviews) %>");
-})
+<% if @path[:controller] == "shops" && @path[:action] == "show" %>
+  $(function(){
+    $("#shop-review-content").html("<%= j(render"reviews", reviews: @reviews) %>");
+    $("#flash-message").html("<%= j(render "shared/flash") %>");
+    $("#shop-avg-rate").html("<%= j(render "shared/star_rate", shop_id: @shop_id, reviews: @reviews) %>");
+  })
+<% elsif @path[:controller] == "reviews" && @path[:action] == "index" %>
+    $(function(){
+    $("#user-review-inner").html("<%= j(render "my_review_index", reviews: @my_reviews) %>");
+    $("#flash-message").html("<%= j(render "shared/flash") %>");
+  })
+<% end %>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -1,0 +1,8 @@
+<div class="user-review-wrapper">
+  <%= render "shared/sidebar" %>
+  <div class="container">
+    <div class="user-review-inner" id="user-review-inner">
+      <%= render "my_review_index", reviews: @my_reviews %>
+    </div>
+  </div>
+</div>

--- a/app/views/reviews/update.js.erb
+++ b/app/views/reviews/update.js.erb
@@ -1,8 +1,18 @@
-$(function(){
-  $(".review-form").val("");
-  $("#review-error").remove();
-  $("#reviewEditModal<%= @review.id %>").modal("hide");
-  $("#flash-message").html("<%= j(render "shared/flash") %>");
-  $("#shop-avg-rate").html("<%= j(render "shared/star_rate", shop_id: @shop_id, reviews: @reviews) %>");
-  $("#shop-review-content").html("<%= j(render "reviews", reviews: @reviews) %>");
-})
+<% if @path[:controller] == "shops" && @path[:action] == "show" %>
+  $(function(){
+    $(".review-form").val("");
+    $("#review-error").remove();
+    $("#reviewEditModal<%= @review.id %>").modal("hide");
+    $("#flash-message").html("<%= j(render "shared/flash") %>");
+    $("#shop-avg-rate").html("<%= j(render "shared/star_rate", shop_id: @shop_id, reviews: @reviews) %>");
+    $("#shop-review-content").html("<%= j(render "reviews", reviews: @reviews) %>");
+  })
+<% elsif @path[:controller] == "reviews" && @path[:action] == "index" %>
+  $(function(){
+    $(".review-form").val("");
+    $("#review-error").remove();
+    $("#reviewEditModal<%= @review.id %>").modal("hide");
+    $("#flash-message").html("<%= j(render "shared/flash") %>");
+    $("#user-review-inner").html("<%= j(render "my_review_index", reviews: @my_reviews) %>");
+  })
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,7 +9,7 @@
         <div class="right-nav-wrapper">
           <%= link_to "お気に入り一覧", favorites_path, class: "header-btn md-btn" %>
           <div class="line"></div>
-          <%= link_to "マイページ", root_path, class: "header-btn md-btn" %>
+          <%= link_to "マイページ", edit_user_registration_path, class: "header-btn md-btn" %>
           <div class="line"></div>
           <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "header-btn md-btn" %>
         </div>
@@ -19,17 +19,6 @@
           <% else %>
             <%= image_tag "/default_icon.jpg", id: "current-user-img" %>
           <% end %>
-          <ul class="header-nav-menu" id="nav-menu">
-            <li>
-              <%= link_to "お気に入り一覧", favorites_path %>
-            </li>
-            <li>
-              <%= link_to "設定", root_path %>
-            </li>
-            <li>
-              <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
-            </li>
-          </ul>
         </div>
       </div>
     <% else %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,0 +1,19 @@
+<div class="side-bar-wrapper">
+  <ul>
+    <%= link_to "#" do %>
+      <li class="side-bar-link ">
+        アカウント情報
+      </li>
+    <% end %>
+    <%= link_to "#" do %>
+      <li class="side-bar-link">
+        お気に入り一覧
+      </li>
+    <% end %>
+    <%= link_to "#" do %>
+      <li class="side-bar-link">
+        マイレビュー
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,17 +1,17 @@
 <div class="side-bar-wrapper">
   <ul>
-    <%= link_to "#" do %>
-      <li class="side-bar-link ">
+    <%= link_to edit_user_registration_path do %>
+      <li class="side-bar-link <%= "active" if current_page?(edit_user_registration_path) %>">
         アカウント情報
       </li>
     <% end %>
-    <%= link_to "#" do %>
-      <li class="side-bar-link">
+    <%= link_to favorites_path do %>
+      <li class="side-bar-link <%= "active" if current_page?(favorites_path) %>">
         お気に入り一覧
       </li>
     <% end %>
-    <%= link_to "#" do %>
-      <li class="side-bar-link">
+    <%= link_to  reviews_path do %>
+      <li class="side-bar-link <%= "active" if current_page?(reviews_path) %>">
         マイレビュー
       </li>
     <% end %>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -88,6 +88,7 @@
           <button type="button" class="btn md-btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
           <%= f.hidden_field :user_id, value: current_user.id %>
           <%= f.hidden_field :shop_id, value: @shop_id %>
+          <%= f.hidden_field :shop_name, value: @shop["name"] %>
           <%= f.submit "投稿する", class: "btn md-btn btn-primary" %>
         </div>
       <% end %>

--- a/config/locales/device.ja.yml
+++ b/config/locales/device.ja.yml
@@ -3,6 +3,7 @@ ja:
     attributes:
       user:
         name: 名前
+        avatar: プロフィール画像
         confirmation_sent_at: パスワード確認送信時刻
         confirmation_token: パスワード確認用トークン
         confirmed_at: パスワード確認時刻

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
   resource :shop, only: [:show]
   resources :reviews, only: [:index, :create, :edit, :update, :destroy]
   resources :favorites, only: [:index, :create , :destroy]
-  devise_for :users
+  devise_for :users, controllers: { registrations: 'users/registrations' }
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root                to: 'searches#top'
   get 'around_shops', to: 'searches#around_shops'
   resource :shop, only: [:show]
-  resources :reviews, only: [:create, :edit, :update, :destroy]
+  resources :reviews, only: [:index, :create, :edit, :update, :destroy]
   resources :favorites, only: [:index, :create , :destroy]
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,8 +7,8 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 amazon:
-   service: S3
-   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-   region: <%= Rails.application.credentials.dig(:aws, :s3, :region) %>
-   bucket: <%= Rails.application.credentials.dig(:aws, :s3, :bucket) %>
+  service: S3
+  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  region: <%= Rails.application.credentials.dig(:aws, :s3, :region) %>
+  bucket: <%= Rails.application.credentials.dig(:aws, :s3, :bucket) %>

--- a/db/migrate/20220319103739_add_shop_name_to_reviews.rb
+++ b/db/migrate/20220319103739_add_shop_name_to_reviews.rb
@@ -1,0 +1,5 @@
+class AddShopNameToReviews < ActiveRecord::Migration[6.1]
+  def change
+    add_column :reviews, :shop_name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_15_141929) do
+ActiveRecord::Schema.define(version: 2022_03_19_103739) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_141929) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.float "rate", default: 0.0, null: false
+    t.string "shop_name", null: false
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
### 概要
マイページ(お気に入りページ、レビュー一覧ページ、アカウント情報変更ページ）実装

### やったこと

- [ ] マイレビュー一覧ページ作成
　ページ内で編集削除可能
- [ ] アカウント情報編集ページ作成
　プロフィール画像変更機能追加
　アカウント編集、削除機能
- [ ] マイページ内のサイドバーを作成しパーシャル化
- [ ] お気に入り一覧ページ、レビュー一覧ページ、アカウント編集ページへサイドバー挿入
- [ ] プロフィール画像のバリデーション作成
　サイズ1MBまで、拡張子はjpg jpeg png

- [ ] パスワードのバリデーション作成
　英数字混合