### PR TITLE
Docker環境でSystemspecを使うための設定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       - TZ='Asia/Tokyo'
       - WEBPACKER_DEV_SERVER_HOST=webpacker
+      - "SELENIUM_DRIVER_URL=http://selenium_chrome:4444/wd/hub"
     env_file:
       - .env
     tty: true
@@ -37,6 +38,10 @@ services:
       - gem_data:/usr/local/bundle
     ports:
       - '127.0.0.1:3035:3035'
+  selenium_chrome:
+    image: selenium/standalone-chrome-debug
+    logging:
+      driver: none
   mysql:
     image: mysql:8.0
     volumes:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require 'capybara/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,13 @@
+require 'capybara/rspec'
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome, options: {
+      browser: :remote,
+      url: ENV.fetch("SELENIUM_DRIVER_URL"),
+      desired_capabilities: :chrome
+    }
+    Capybara.server_host = 'app'
+    Capybara.app_host="http://#{Capybara.server_host}"
+  end
+end


### PR DESCRIPTION
### 概要
Docker環境でSystemspecを使用する

### やったこと

- [ ] dockerにchrome用のコンテナを追加
　dockerにはchromeがないため必要。

- [ ] capybaraでchromeを使用する設定
