### PR TITLE
ページタイトルの修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  BASE_TITLE = "CAFE APP".freeze
+  BASE_TITLE = "WAN SEARCH".freeze
 
   def full_title(page_title: '')
     if page_title.blank?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,20 +3,20 @@ require 'rails_helper'
 RSpec.describe ApplicationHelper, type: :helper do
   describe "full_titleメソッドのテスト" do
     context "page_titleがあるとき" do
-      it "「page_title - CAFE APP」と表示すること" do
-        expect(helper.full_title(page_title: "test_title")).to eq "test_title - CAFE APP"
+      it "「page_title - WAN SEARCH」と表示すること" do
+        expect(helper.full_title(page_title: "test_title")).to eq "test_title - WAN SEARCH"
       end
     end
 
     context "page_titleが空白のとき" do
-      it "「CAFE APP」と表示すること" do
-        expect(helper.full_title(page_title: "")).to eq "CAFE APP"
+      it "「WAN SEARCH」と表示すること" do
+        expect(helper.full_title(page_title: "")).to eq "WAN SEARCH"
       end
     end
 
     context "page_titleがnilのとき" do
-      it "「BIGBAG Store」と表示すること" do
-        expect(helper.full_title(page_title: nil)).to eq "CAFE APP"
+      it "「WAN SEARCH」と表示すること" do
+        expect(helper.full_title(page_title: nil)).to eq "WAN SEARCH"
       end
     end
   end

--- a/spec/systems/title_spec.rb
+++ b/spec/systems/title_spec.rb
@@ -3,23 +3,23 @@ require 'rails_helper'
 RSpec.describe "動的タイトル表示", type: :system do
   describe "非ログイン時の動的なタイトル表示機能" do
     context "topページの時" do
-      it "タイトルが 'CAFE APP'であること" do
+      it "タイトルが 'WAN SEARCH'であること" do
         visit root_path
-        expect(page).to have_title 'CAFE APP'
+        expect(page).to have_title 'WAN SEARCH'
       end
     end
 
     context "users/sign_inのとき" do
-      it "タイトルが 'ログイン - CAFE APP'であること" do
+      it "タイトルが 'ログイン - WAN SEARCH'であること" do
         visit new_user_session_path
-        expect(page).to have_title 'ログイン - CAFE APP'
+        expect(page).to have_title 'ログイン - WAN SEARCH'
       end
     end
 
     context "users/sign_inのとき" do
-      it "タイトルが 'アカウント登録 - CAFE APP'であること" do
+      it "タイトルが 'アカウント登録 - WAN SEARCH'であること" do
         visit new_user_registration_path
-        expect(page).to have_title 'アカウント登録 - CAFE APP'
+        expect(page).to have_title 'アカウント登録 - WAN SEARCH'
       end
     end
   end
@@ -35,23 +35,23 @@ RSpec.describe "動的タイトル表示", type: :system do
     end
 
     context "/favoritesのとき" do
-      it "タイトルが 'お気に入り一覧 - CAFE APP'であること" do
+      it "タイトルが 'お気に入り一覧 - WAN SEARCH'であること" do
         visit favorites_path
-        expect(page).to have_title 'お気に入り一覧 - CAFE APP'
+        expect(page).to have_title 'お気に入り一覧 - WAN SEARCH'
       end
     end
 
     context "/reviewsのとき" do
-      it "タイトルが 'マイレビュー一覧 - CAFE APP'であること" do
+      it "タイトルが 'マイレビュー一覧 - WAN SEARCH'であること" do
         visit reviews_path
-        expect(page).to have_title 'マイレビュー一覧 - CAFE APP'
+        expect(page).to have_title 'マイレビュー一覧 - WAN SEARCH'
       end
     end
 
     context "/users/editのとき" do
-      it "タイトルが 'アカウント情報 - CAFE APP'であること" do
+      it "タイトルが 'アカウント情報 - WAN SEARCH'であること" do
         visit edit_user_registration_path
-        expect(page).to have_title 'アカウント情報 - CAFE APP'
+        expect(page).to have_title 'アカウント情報 - WAN SEARCH'
       end
     end
   end


### PR DESCRIPTION
### 概要
変更が漏れていたページタイトルを'WAN SEARCH'に修正

### やったこと

- [ ] ベースのページタイトルをCAFEAPPからWAN SEARCHに修正
- [ ] それに伴うテストの修正